### PR TITLE
BREAKING: Drop node 9; add node 10+11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 node_js:
   - "node"
-  - "9"
+  - "11"
+  - "10"
   - "8"
 
 before_install:


### PR DESCRIPTION
Update the test setup to run on current node versions. The current
versions are 8, 10, 11 and 12.

This commit drops support for node 9.