### PR TITLE
ci: Add GitHub Actions workflow

### DIFF
--- a/.github/workflows/yarn-test.yml
+++ b/.github/workflows/yarn-test.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [24, 22, 20]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "yarn"
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Build package
+        run: yarn build
+
+      - name: Run tests
+        run: yarn test


### PR DESCRIPTION
Add modern GitHub Actions CI workflow to replace Travis CI.

## Changes
- Add GitHub Actions workflow with Node.js 20, 22, 24 matrix
- Use actions/checkout@v4 and actions/setup-node@v4
- Run build and test steps
- Configure for master branch (to match current default branch)

## Benefits
- Travis CI is being phased out for open source projects
- GitHub Actions provides better integration with GitHub
- Faster CI runs
- Test on current Node versions (20, 22, 24)

## Note
This workflow uses `branches: [master]` to match the current default branch name. A separate PR will modernize the entire build toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
