### PR TITLE
docs(readme): Remove commonjs example

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ $ npm install get-best-contrast-color
 ## Usage
 ```js
 import bestContrast from 'get-best-contrast-color';
-// If you're not using EMS but CommonJS:
-// const bestContrast = require('get-best-contrast-color').default;
 
 const background1 = 'palevioletred';
 const background2 = 'saddlebrown';


### PR DESCRIPTION
We don't output commonjs now.